### PR TITLE
remove #![feature(iter_arith)]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@
 
 #![deny(warnings)]
 
-#![feature(iter_arith)]
 #![feature(rustc_private)]
 #![feature(rustdoc)]
 #![feature(question_mark)]


### PR DESCRIPTION
I’ve got the error when trying to install rustbook.
So I fix this error.

```
➜  the-rust-programming-language-ja git:(master) rustup run nightly rustc --version
rustc 1.13.0-nightly (3c5a0fa45 2016-08-22)
➜  the-rust-programming-language-ja git:(master) rustup run nightly cargo install --git https://github.com/rust-lang-ja/rustbook.git --branch master --verbose
    Updating git repository `https://github.com/rust-lang-ja/rustbook.git`
   Compiling rustbook v0.4.2 (https://github.com/rust-lang-ja/rustbook.git#c6583715)
     Running `rustc /Users/toku345/.cargo/git/checkouts/rustbook-b2c3bfd092fd80dd/master/src/main.rs --crate-name rustbook --crate-type bin -C opt-level=3 -C metadata=07bad191fe74208f --out-dir /var/folders/5w/1zqzlqhj7m97shs94zwnxwf00000gp/T/cargo-install.TRydNNo2ImMp/release --emit=dep-info,link -L dependency=/var/folders/5w/1zqzlqhj7m97shs94zwnxwf00000gp/T/cargo-install.TRydNNo2ImMp/release/deps`
error: this feature has been stable since 1.11.0. Attribute no longer needed
  --> /Users/toku345/.cargo/git/checkouts/rustbook-b2c3bfd092fd80dd/master/src/main.rs:13:12
   |
13 | #![feature(iter_arith)]
   |            ^^^^^^^^^^
   |
note: lint level defined here
  --> /Users/toku345/.cargo/git/checkouts/rustbook-b2c3bfd092fd80dd/master/src/main.rs:11:9
   |
11 | #![deny(warnings)]
   |         ^^^^^^^^

error: aborting due to previous error

error: failed to compile `rustbook v0.4.2 (https://github.com/rust-lang-ja/rustbook.git#c6583715)`, intermediate artifacts can be found at `/var/folders/5w/1zqzlqhj7m97shs94zwnxwf00000gp/T/cargo-install.TRydNNo2ImMp`

Caused by:
  Could not compile `rustbook`.

Caused by:
  Process didn't exit successfully: `rustc /Users/toku345/.cargo/git/checkouts/rustbook-b2c3bfd092fd80dd/master/src/main.rs --crate-name rustbook --crate-type bin -C opt-level=3 -C metadata=07bad191fe74208f --out-dir /var/folders/5w/1zqzlqhj7m97shs94zwnxwf00000gp/T/cargo-install.TRydNNo2ImMp/release --emit=dep-info,link -L dependency=/var/folders/5w/1zqzlqhj7m97shs94zwnxwf00000gp/T/cargo-install.TRydNNo2ImMp/release/deps` (exit code: 101)
```
↓

```
➜  the-rust-programming-language-ja git:(master) rustup run nightly cargo install --git https://github.com/toku345/rustbook.git --branch remove_fixture_iter_arith
    Updating git repository `https://github.com/toku345/rustbook.git`
   Compiling rustbook v0.4.2 (https://github.com/toku345/rustbook.git?branch=remove_fixture_iter_arith#de5267a1)
    Finished release [optimized] target(s) in 5.50 secs
  Installing /Users/toku345/.cargo/bin/rustbook
```