### PR TITLE
meta data `noindex` と、`caveat` を任意で指定できる機能の追加

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -119,13 +119,6 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
         let prelude = tmp.path().join("prelude.html");
         {
             let mut buffer = BufWriter::new(File::create(&prelude)?);
-            if Path::new("caveat.inc").exists() {
-                let mut caveat_data = String::new();
-                let mut f = fs::File::open("caveat.inc")?;
-                let _ = f.read_to_string(&mut caveat_data)?;
-
-                buffer.write(caveat_data.as_bytes())?;
-            }
             writeln!(&mut buffer, r#"
                 <div id="nav">
                     <button id="toggle-nav">
@@ -138,6 +131,13 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
             let _ = write_toc(book, &item, &mut buffer);
             writeln!(&mut buffer, "<div id='page-wrapper'>")?;
             writeln!(&mut buffer, "<div id='page'>")?;
+            if Path::new("caveat.inc").exists() {
+                let mut caveat_data = String::new();
+                let mut f = fs::File::open("caveat.inc")?;
+                let _ = f.read_to_string(&mut caveat_data)?;
+
+                buffer.write(caveat_data.as_bytes())?;
+            }
         }
 
         // write the postlude to a temporary HTML file for rustdoc inclusion


### PR DESCRIPTION
## 経緯

「プログラミング言語 Rust」で検索した際、しばしば第一版のサイトがサジェストされてしまう問題がある。
この対策として、 noindex の付与と、第二版への誘導を追加しようとしたところ https://github.com/rust-lang-ja/the-rust-programming-language-ja への変更だけでは対応が難しいことが判明したため、第一版用に fork した rustbook (本リポジトリ) に修正を加えることとした。

対応としては、第一版のサイトを build した際、下記の対応が自動的になされるようにするのがゴールとする。

* `<head>` に `noindex` を追加
* `<body>` の直下に最新ドキュメントへの誘導を追加

## 修正内容

本来であればどちらの機能も

* `--html-in-header`
* `--html-before-content`

を外から指定して利用すべきですが、https://github.com/rust-lang-ja/rustbook/blob/master/src/build.rs#L178-L188 のように `rustbook` が引数の数を見て処理の制御を行っているため処理を直接埋め込む対応としました。